### PR TITLE
calculate percent of all new growth

### DIFF
--- a/process/ACS/UnitsInStructureByTenure.R
+++ b/process/ACS/UnitsInStructureByTenure.R
@@ -176,7 +176,8 @@ calc_share_growth <- function(table) {
     arrange(name, building_size) %>% 
     group_by(name, building_size) %>% 
     mutate(growth = estimate-lag(estimate)) %>% 
-    mutate(growth_share = growth/lag(total)) %>% 
+    mutate(total_diff = total - lag(total)) %>% 
+    mutate(growth_share = growth/total_diff) %>% 
     arrange(factor(name, levels = c('King County', 'Kitsap County', 'Pierce County', 'Snohomish County', 'Region')))
 }
 


### PR DESCRIPTION
> It looks like this is calculated by "growth_2010-21" / "total 2010". Instead I would like it to be calculated as "growth_2010-21" / ("Total_2021" - "Total_2010").  Basically I want to know what percent of all new growth in that county was SF homes, for example.